### PR TITLE
UserControllerTest 테스트 작성

### DIFF
--- a/src/test/java/com/example/onjeong/user/UserControllerTest.java
+++ b/src/test/java/com/example/onjeong/user/UserControllerTest.java
@@ -1,0 +1,248 @@
+package com.example.onjeong.user;
+
+import com.example.onjeong.Config.SecurityConfig;
+import com.example.onjeong.user.controller.UserController;
+import com.example.onjeong.user.dto.UserAccountDto;
+import com.example.onjeong.user.dto.UserDeleteDto;
+import com.example.onjeong.user.dto.UserJoinDto;
+import com.example.onjeong.user.dto.UserJoinedDto;
+import com.example.onjeong.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = UserController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfig.class
+                )})
+public class UserControllerTest {
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @TestConfiguration
+    static class DefaultConfigWithoutCsrf extends WebSecurityConfigurerAdapter {
+        @Override
+        protected void configure(final HttpSecurity http) throws Exception {
+            super.configure(http);
+            http.csrf().disable();
+        }
+    }
+
+
+    @Nested
+    class 회원가입{
+        @Nested
+        class 가족회원이없는회원가입{
+            @Test
+            @WithMockUser
+            void 가족회원이없는회원가입_성공() throws Exception{
+                //given
+                final String url = "/accounts";
+                final UserJoinDto userJoinDto= userJoinDto();
+                doReturn(false).when(userService).isUserNicknameDuplicated(userJoinDto.getUserNickname());
+
+                //when
+                ResultActions resultActions = mockMvc.perform(
+                        MockMvcRequestBuilders.post(url)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(userJoinDto))
+                );
+
+                //then
+                resultActions.andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code", equalTo("U001")));
+            }
+
+            @Test
+            @WithMockUser
+            void 가족회원이없는회원가입_실패() throws Exception{
+                //given
+                final String url = "/accounts";
+                final UserJoinDto userJoinDto= userJoinDto();
+                doReturn(true).when(userService).isUserNicknameDuplicated(userJoinDto.getUserNickname());
+
+                //when
+                ResultActions resultActions = mockMvc.perform(
+                        MockMvcRequestBuilders.post(url)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(userJoinDto))
+                );
+
+                //then
+                resultActions.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.status", equalTo(Integer.valueOf("400"))))
+                        .andExpect(jsonPath("$.code", equalTo("U003")))
+                        .andExpect(jsonPath("$.message", equalTo("USER NICKNAME DUPLICATION")));
+            }
+        }
+
+
+        @Nested
+        class 가족회원이있는회원가입{
+            @Test
+            @WithMockUser
+            void 가족회원이있는회원가입_성공() throws Exception{
+                //given
+                final String url = "/accounts/joined";
+                final UserJoinedDto userJoinedDto= userJoinedDto();
+                doReturn(false).when(userService).isUserNicknameDuplicated(userJoinedDto.getUserNickname());
+
+                //when
+                ResultActions resultActions = mockMvc.perform(
+                        MockMvcRequestBuilders.post(url)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(userJoinedDto))
+                );
+
+                //then
+                resultActions.andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code", equalTo("U001")));
+            }
+
+            @Test
+            @WithMockUser
+            void 가족회원이있는회원가입_실패() throws Exception{
+                //given
+                final String url = "/accounts/joined";
+                final UserJoinedDto userJoinedDto= userJoinedDto();
+                doReturn(true).when(userService).isUserNicknameDuplicated(userJoinedDto.getUserNickname());
+
+                //when
+                ResultActions resultActions = mockMvc.perform(
+                        MockMvcRequestBuilders.post(url)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(userJoinedDto))
+                );
+
+                //then
+                resultActions.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.status", equalTo(Integer.valueOf("400"))))
+                        .andExpect(jsonPath("$.code", equalTo("U003")))
+                        .andExpect(jsonPath("$.message", equalTo("USER NICKNAME DUPLICATION")));
+            }
+        }
+    }
+
+    @Test
+    @WithMockUser
+    void 회원정보수정_성공() throws Exception{
+        //given
+        final String url = "/accounts/user";
+        final UserAccountDto userAccountDto= userAccountDto();
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.put(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userAccountDto))
+        );
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.code", equalTo("U004")));
+    }
+
+    @Test
+    @WithMockUser
+    void 회원탈퇴_성공() throws Exception{
+        //given
+        final String url = "/accounts";
+        final UserDeleteDto userDeleteDto= userDeleteDto();
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.delete(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(userDeleteDto))
+        );
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.code", equalTo("U005")));
+    }
+
+    @Test
+    @WithMockUser
+    void 유저기본정보조회_성공() throws Exception{
+        //given
+        final String url = "/users";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.code", equalTo("U006")));
+    }
+
+
+    private UserDeleteDto userDeleteDto(){
+        return UserDeleteDto.builder()
+                .userPassword("test")
+                .build();
+    }
+
+    private UserJoinDto userJoinDto(){
+        return UserJoinDto.builder()
+                .userName("ParkJunHui")
+                .userNickname("jun")
+                .userPassword("pw123")
+                .userStatus("daughter")
+                .userBirth(LocalDate.now())
+                .build();
+    }
+
+    private UserJoinedDto userJoinedDto(){
+        return UserJoinedDto.builder()
+                .userName("user1")
+                .userNickname("user")
+                .userPassword("pw123")
+                .userStatus("daughter")
+                .userBirth(LocalDate.now())
+                .joinedNickname("user2")
+                .build();
+    }
+
+    private UserAccountDto userAccountDto(){
+        return UserAccountDto.builder()
+                .userName("ParkJunHui")
+                .userPassword("pw123")
+                .userStatus("daughter")
+                .userBirth(LocalDate.now())
+                .build();
+    }
+}


### PR DESCRIPTION
[수정된 부분]

UserControllerTest 테스트 작성
저번 pr때 Repository, Service까지 테스트 작성하여 이번에는 Controller 테스트를 작성했습니다.
UserController와 관련된 API를 단위테스트로 구현했습니다.
@nested 어노테이션을 사용하여 관심사가 비슷한 메소드끼리 묶어놔 코드 가독성을 높였습니다.
@WebMvcTest를 사용하여 테스트하기 때문에 웹과 관련된 빈만 주입되고, @service @repository 컴포넌트는 주입되지않아 이로인해 config파일에서 에러가 발생했습니다. 그래서 SecurityConfig.class는 탐색하지않도록 설정하였고, 시큐리티와 관련하여 설정이 필요한 경우에는 DefaultConfigWithoutCsrf 클래스를 추가하여 필요한 기능만 설정하도록 구현했습니다.