### PR TITLE
fix: json 파일 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out/
 !**/src/test/**/out/
 application.properties
 aws.yml
+firebase_service_key.json
 
 ### NetBeans ###
 /nbproject/private/


### PR DESCRIPTION
## 개요
firebase 관련 json 파일이 github에 업로드 되는 오류가 있었어서, gitignore 파일에 해당 json 파일 추가하여 git에 업로드 되지 않도록 수정했습니다.

## 작업사항
gitignore 파일에 firebase_service_key.json 추가했습니다.