### PR TITLE
refactor: fcm 에러와 무관하게 메인 로직 수정되도록 구현

### DIFF
--- a/src/main/java/com/example/onjeong/fcm/FCMService.java
+++ b/src/main/java/com/example/onjeong/fcm/FCMService.java
@@ -59,14 +59,7 @@ public class FCMService {
         String token = mail.getReceiveUser().getDeviceToken();
         String content = mail.getSendUser().getUserStatus() + "로부터 메일이 도착했습니다.";
 
-        Message message = Message.builder()
-                .putData("time", LocalDateTime.now().toString())
-                .setNotification(new Notification("On:Jeong", content))
-                .setToken(token)
-                .build();
-
-        String response = FirebaseMessaging.getInstance().send(message);
-        System.out.println("메시지 전송 알림 완료 : " + response);
+        sendPersonalAlarm(content, token);
     }
 
     public void sendFamilyCheck(Answer answer) throws FirebaseMessagingException {
@@ -90,14 +83,7 @@ public class FCMService {
             String content = notAnsweredFamily.get(0).getUserStatus() + "님만 답변하면 가족 전체의 답변이 완성됩니다";
 
             // 알림 범위 논의 필요
-            Message message = Message.builder()
-                    .putData("time", LocalDateTime.now().toString())
-                    .setNotification(new Notification("On:Jeong", content))
-                    .setToken(token)
-                    .build();
-
-            String response = FirebaseMessaging.getInstance().send(message);
-            System.out.println("메시지 전송 알림 완료 : " + response);
+            sendPersonalAlarm(content, token);
         }
     }
 
@@ -107,14 +93,9 @@ public class FCMService {
         String topic = board.getFamily().getFamilyId().toString();
         String content = board.getUser().getUserStatus() + "님이 오늘의 기록을 작성했습니다.";
 
-        Message message = Message.builder()
-                .putData("time", LocalDateTime.now().toString())
-                .setNotification(new Notification("OnJeong", content))
-                .setTopic(topic)
-                .build();
+        //알림 전송
+        sendFamilyAlarm(content, topic);
 
-        String response = FirebaseMessaging.getInstance().send(message);
-        System.out.println("메시지 전송 알림 완료 : " + response);
     }
 
     public void sendAnswer(Answer answer) throws FirebaseMessagingException {
@@ -122,14 +103,7 @@ public class FCMService {
         String topic = answer.getUser().getFamily().getFamilyId().toString();
         String content = answer.getUser().getUserStatus() + "님이 이주의 문답에 대한 답변을 작성했습니다.";
 
-        Message message = Message.builder()
-                .putData("time", LocalDateTime.now().toString())
-                .setNotification(new Notification("On:Jeong", content))
-                .setTopic(topic)
-                .build();
-
-        String response = FirebaseMessaging.getInstance().send(message);
-        System.out.println("메시지 전송 알림 완료 : " + response);
+        sendFamilyAlarm(content, topic);
     }
 
     public void sendProfileModify(Profile profile) throws FirebaseMessagingException {
@@ -137,14 +111,7 @@ public class FCMService {
         String topic = profile.getFamily().getFamilyId().toString();
         String content = profile.getUser().getUserStatus() + "의 프로필이 수정되었습니다.";
 
-        Message message = Message.builder()
-                .putData("time", LocalDateTime.now().toString())
-                .setNotification(new Notification("On:Jeong", content))
-                .setTopic(topic)
-                .build();
-
-        String response = FirebaseMessaging.getInstance().send(message);
-        System.out.println("메시지 전송 알림 완료 : " + response);
+        sendFamilyAlarm(content, topic);
     }
 
     public void sendAnnivarsary() throws FirebaseMessagingException {
@@ -157,14 +124,34 @@ public class FCMService {
             String topic = a.getFamily().getFamilyId().toString();
             String content = a.getAnniversaryContent() + "이 하루 전입니다.";
 
+            sendFamilyAlarm(content, topic);
+        }
+    }
+
+
+    public void sendPersonalAlarm(String content, String token) throws FirebaseMessagingException {
+        try{
             Message message = Message.builder()
                     .putData("time", LocalDateTime.now().toString())
                     .setNotification(new Notification("On:Jeong", content))
+                    .setToken(token)
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(message);
+            System.out.println("메시지 전송 알림 완료 : " + response);
+        } catch (Exception e){} // 에러가 발생해도 무시하고 다음 코드 진행
+    }
+
+    public void sendFamilyAlarm(String content, String topic) throws FirebaseMessagingException {
+        try{
+            Message message = Message.builder()
+                    .putData("time", LocalDateTime.now().toString())
+                    .setNotification(new Notification("OnJeong", content))
                     .setTopic(topic)
                     .build();
 
             String response = FirebaseMessaging.getInstance().send(message);
             System.out.println("메시지 전송 알림 완료 : " + response);
-        }
+        } catch (Exception e){} // 에러가 발생해도 무시하고 다음 코드 진행
     }
 }


### PR DESCRIPTION
## 개요
사용자에게 알림을 전송하는 모든 부분(ex. 메일 전송, 오늘의 기록 작성 등)에서 사용자에게 알림 전송이 실패하면 아예 메인 로직이 진행되지 않고 에러 코드가 반환되는 부분을 수정했습니다. 

## 작업사항
- FCM 에러처리 로직을 작성하였습니다.
- FCM Service에 공통적으로 적용되어 있는 메시징 부분을 따로 함수를 만들어 분리하여, 조금 더 객체지향적인 코드로 만들었습니다.

### 변경전
FCM 에러처리 관련 함수가 작성되어 있지 않았습니다.

### 변경후
먼저 FCM을 사용할 때 메시징 부분(에러가 발생하는 부분)을 sendPersonalAlarm, sendFamilyAlarm으로 분리하였습니다.
그리고 try-catch 문을 사용하여 어떠한 Exception이든 catch 되면 아무런 작업을 하지 않고 지나가도록 빈 함수로 에러 처리를 해주었습니다.
저희 프로젝트에서는 예상되는 에러 상황에 대해 커스텀 된 에러를 throw 하여 처리를 진행하였으나, 알림의 경우는 그렇게 진행할 수가 없어 try-catch문을 사용하였는데요.
먼저 알림이 전송되는 FirebaseMessaging.getInstance().send() 함수의 내부 로직을 알 수 없어 어떤 부분에서 에러가 나는 지를 알 수 없어 커스텀 에러를 throw 할 위치를 찾지 못하였으며,
해당 함수가 FirebaseMessagingException과 같이 FCM에 한정되는 에러만을 반환하는 것이 아니라,  IllegalArgumentException와 같이 다른 서비스에서도 발생할 수 있는 오류들을 반환하는 경우도 있어 try-catch문을 사용하여 모든 에러를 무시하도록 한 번에 처리했습니다.

## 기타 및 향후 개발 목표
오늘의 기록 작성 시, 작성자 본인에게도 알림이 가도록 구현되어 있어 이 부분 수정 할 예정입니다!
(EX. 김하은님이 기록을 작성했습니다! 가 김하은의 기기에도 알림이 감)