### PR TITLE
feat : id 체크하는 로직 추가

### DIFF
--- a/src/main/java/com/example/onjeong/result/ResultCode.java
+++ b/src/main/java/com/example/onjeong/result/ResultCode.java
@@ -15,6 +15,7 @@ public enum ResultCode {
     GET_USER_SUCCESS(200,"U006","유저 기본정보를 조회했습니다."),
     NEW_TOKEN_SUCCESS(200,"U007","새로운 Access Token을 발급했습니다."),
     GET_HOME_SUCCESS(200,"U008","home을 조회했습니다."),
+    CHECK_ID_SUCCESS(200,"U009","id 체크에 성공했습니다."),
 
     // Anniversary
     GET_ALL_ANNIVERSARY_SUCCESS(200, "A001", "월별 모든 특수일정을 조회했습니다."),

--- a/src/main/java/com/example/onjeong/user/controller/UserController.java
+++ b/src/main/java/com/example/onjeong/user/controller/UserController.java
@@ -106,4 +106,20 @@ public class UserController {
         headers.add(AuthConstants.AUTH_HEADER_ACCESS, newAccessToken);
         return ResponseEntity.ok().headers(headers).body(ResultResponse.of(ResultCode.NEW_TOKEN_SUCCESS));
     }
+
+    @ApiOperation(value="사용할 수 있는 아이디인지 체크")
+    @GetMapping(value="/check/id/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResultResponse> isAvailableId(@PathVariable("id") String userNickname){
+        boolean isAvailable= true;
+        if(userService.isUserNicknameDuplicated(userNickname)) isAvailable= false;
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHECK_ID_SUCCESS, UserCheckDto.builder().isAvailable(isAvailable).build()));
+    }
+
+    @ApiOperation(value="초대가족 아이디 존재유무 체크")
+    @GetMapping(value="/check/joined-id/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResultResponse> isAvailableJoinedId(@PathVariable("id") String userNickname){
+        boolean isAvailable= true;
+        if(!userService.isUserNicknameDuplicated(userNickname)) isAvailable= false;
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHECK_ID_SUCCESS, UserCheckDto.builder().isAvailable(isAvailable).build()));
+    }
 }

--- a/src/main/java/com/example/onjeong/user/dto/UserCheckDto.java
+++ b/src/main/java/com/example/onjeong/user/dto/UserCheckDto.java
@@ -1,0 +1,14 @@
+package com.example.onjeong.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserCheckDto {
+    private boolean isAvailable;
+}


### PR DESCRIPTION
## 개요
회원가입할때 '사용할 수 있는 id인가' '초대가족 id가 실제로 존재하는 값인가'를 알려주도록 id를 체크하는 로직을 추가했습니다.

## 작업사항
id를 체크하는 api를 만들어 클라이언트가 api요청하면, 요청값에 담긴 id(userNickname)를 넘겨받아 서버에서 id를 사용할 수 있을지 또는 해당 id가 존재한지를 체크하여 true, false로 반환하도록 구현했습니다.
그리고 변경사항은 온정 노션에 표시해놨습니다.

## 변경로직
userService에는 id가 존재하는지를 체크하는 isUserNicknameDuplicated메소드가 원래 구현돼있었습니다. 이 메소드를 재사용해 id를 체크하여 서비스는 변경사항 없고 컨트롤러만 변경사항 있습니다.
1. '사용할 수 있는 id인가' 체크
  - isUserNicknameDuplicated가 true면 해당 id가 존재한다는 의미로, id 사용할 수 없으므로 false를 반환하도록 구현했습니다.
2. '초대가족 id가 실제로 존재하는 값인가' 체크
  - isUserNicknameDuplicated가 false면 해당 id가 존재하지 않다는 의미로, 사용자가 초대가족id를 잘못입력했으므로 false를  반환하도록 구현했습니다.

현진님과 사전에 논의한 결과 체크결과값을 true,false로 반환하도록 구현했습니다.

### 변경전
id를 체크하는 로직이 없었습니다.

### 변경후
id를 체크하는 로직을 추가했습니다.

## 사용방법
스웨거를 통해 해당 api를 테스트할 수 있습니다.

## 향후목표
안정적인 서비스 구현을 위해 CI, CD나 MSA와 같은 기술들을 공부해볼 계획입니다.
