### PR TITLE
feat: 이주의문답 모아보기 기능 추가

### DIFF
--- a/src/main/java/com/example/onjeong/question/controller/QuestionController.java
+++ b/src/main/java/com/example/onjeong/question/controller/QuestionController.java
@@ -12,6 +12,9 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,14 +29,14 @@ public class QuestionController {
 
     @ApiOperation(value = "이주의 문답 질문 보여주기")
     @GetMapping("/questions")
-    public ResponseEntity<ResultResponse> showQuestion() {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_QUESTION_SUCCESS, questionService.showQuestion()));
+    public ResponseEntity<ResultResponse> showQuestion(@PageableDefault(size=20, sort = "questionId", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_QUESTION_SUCCESS, questionService.showQuestion(pageable)));
     }
 
     @ApiOperation(value = "이주의 문답 답변들 보여주기")
-    @GetMapping("/answers")
-    public ResponseEntity<ResultResponse> showAllAnswer() {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ANSWERS_SUCCESS, questionService.showAllAnswer()));
+    @GetMapping("/answers/{questionId}")
+    public ResponseEntity<ResultResponse> showAllAnswer(@PathVariable("questionId") Long questionId) {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ANSWERS_SUCCESS, questionService.showAllAnswer(questionId)));
     }
 
     @ApiOperation(value = "이주의 문답에 답변한 가족 리스트")

--- a/src/main/java/com/example/onjeong/question/repository/QuestionRepository.java
+++ b/src/main/java/com/example/onjeong/question/repository/QuestionRepository.java
@@ -3,6 +3,8 @@ package com.example.onjeong.question.repository;
 
 import com.example.onjeong.family.domain.Family;
 import com.example.onjeong.question.domain.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +19,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             value = "SELECT * FROM question q WHERE q.family_id = :id " +
                     "ORDER BY q.question_time DESC limit 1")
     Question findWeeklyQuestion(@Param("id") Long id);
+
+    Page<Question> findAllByFamily(Pageable pageable, Family family);
 }

--- a/src/test/java/com/example/onjeong/question/QuestionControllerTest.java
+++ b/src/test/java/com/example/onjeong/question/QuestionControllerTest.java
@@ -5,9 +5,9 @@ import com.example.onjeong.Config.WebMvcConfig;
 import com.example.onjeong.coin.domain.CoinHistoryType;
 import com.example.onjeong.coin.service.CoinService;
 import com.example.onjeong.family.domain.Family;
-import com.example.onjeong.fcm.FCMService;
 import com.example.onjeong.mail.domain.Mail;
 import com.example.onjeong.mail.dto.MailRequestDto;
+import com.example.onjeong.notification.service.NotificationService;
 import com.example.onjeong.question.controller.QuestionController;
 import com.example.onjeong.question.domain.Answer;
 import com.example.onjeong.question.domain.Question;
@@ -60,7 +60,7 @@ class QuestionControllerTest {
     private CoinService coinService;
 
     @MockBean
-    private FCMService fcmService;
+    private NotificationService notificationService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -98,7 +98,8 @@ class QuestionControllerTest {
     @WithMockUser
     void 이주의답변확인() throws Exception {
         //given
-        final String uri = "/answers";
+        final Long questionId = 1L;
+        final String uri = "/answers/" + questionId;
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -151,8 +152,8 @@ class QuestionControllerTest {
                     .andExpect(jsonPath("$.code", equalTo("Q004")));
 
             verify(coinService, times(1)).coinSave(CoinHistoryType.ANSWER, 10);
-            verify(fcmService,times(1)).sendAnswer(isA(Answer.class));
-            verify(fcmService,times(1)).sendFamilyCheck(isA(Answer.class));
+            verify(notificationService,times(1)).sendAnswer(isA(Answer.class));
+            verify(notificationService,times(1)).sendFamilyCheck(isA(Answer.class));
         }
 
 


### PR DESCRIPTION
## 개요
이주의 문답을 옛날 것까지 확인할 수 있도록 추가하였습니다.

## 작업사항
이때까지 답변한 모든 질문의 리스트를 볼 수 있게 작업하였고, 이 과정에서 답변한 질문들을 페이징처리 하였습니다.

## 변경로직
이 주의 질문을 get 해 올 때, paging 처리 하여 가져오도록 했습니다.
확인할 수 있는 질문의 수가 늘어났으므로, 각 질문에 대한 답변을 볼 수 있도록 답변을 확인 하는 로직에 파라미터로 questionId를 받도록 변경했습니다.

### 변경전
해당 주의 질문, 답변만 확인할 수 있었습니다.

### 변경후
이 주의 질문을 get 해 올 때, paging 처리 하여 가져오도록 변경했습니다.
답변을 확인 하는 로직에 파라미터로 questionId이 추가되었습니다.

## 향후목표
코인 적립 내역 또한 페이징 처리하여, 이전 적립 내역을 계속해서 볼 수 있도록 구현할 예정입니다.