### PR TITLE
refactor: 코인 적립 paging 사용하도록 변경

### DIFF
--- a/src/main/java/com/example/onjeong/coin/repository/CoinHistoryRepository.java
+++ b/src/main/java/com/example/onjeong/coin/repository/CoinHistoryRepository.java
@@ -2,6 +2,8 @@ package com.example.onjeong.coin.repository;
 
 import com.example.onjeong.coin.domain.CoinHistory;
 import com.example.onjeong.coin.domain.CoinHistoryType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,8 +15,8 @@ public interface CoinHistoryRepository extends JpaRepository<CoinHistory, Long> 
 
     @Query(nativeQuery = true,
             value="SELECT * FROM coin_history c WHERE c.family_id = :familyId" +
-                    " ORDER BY c.coin_history_date DESC")
-    List<CoinHistory> findByFamily(@Param("familyId") Long familyId);
+                    " ORDER BY c.coin_history_id DESC")
+    Page<CoinHistory> findByFamily(Pageable pageable, @Param("familyId") Long familyId);
 
     @Query(nativeQuery = true,
             value="SELECT * FROM coin_history c " +

--- a/src/main/java/com/example/onjeong/coin/service/CoinService.java
+++ b/src/main/java/com/example/onjeong/coin/service/CoinService.java
@@ -112,7 +112,7 @@ public class CoinService {
         User user = authUtil.getUserByAuthentication();
         Family family = user.getFamily();
 
-        List<CoinHistory> coinHistoryList = coinHistoryRepository.findByFamily(family.getFamilyId());
+        List<CoinHistory> coinHistoryList = coinHistoryRepository.findByFamily(pageable, family.getFamilyId()).toList();
         List<CoinHistoryDto> coinHistoryDtoList = new ArrayList<>();
 
         for(CoinHistory c : coinHistoryList){

--- a/src/main/java/com/example/onjeong/home/controller/HomeController.java
+++ b/src/main/java/com/example/onjeong/home/controller/HomeController.java
@@ -12,7 +12,10 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,8 +43,8 @@ public class HomeController {
 
     @ApiOperation(value = "패밀리 코인 적립 내역")
     @GetMapping("/histories")
-    public ResponseEntity<ResultResponse> histories() {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_HISTORY_SUCCESS,coinService.coinHistoryList()));
+    public ResponseEntity<ResultResponse> histories(@PageableDefault(size=20, sort = "coin_history_id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_HISTORY_SUCCESS,coinService.coinHistoryList(pageable)));
     }
 
     @ApiOperation(value = "패밀리 코인 보여주기")

--- a/src/test/java/com/example/onjeong/home/CoinRepositoryTest.java
+++ b/src/test/java/com/example/onjeong/home/CoinRepositoryTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -26,11 +29,12 @@ class CoinRepositoryTest {
     void 코인적립내역확인(){
         //given
         final Family family = FamilyUtils.getFamily(50L, 540);
-
+        final Pageable pageable = PageRequest.of(0, 20);
         //when
-        List<CoinHistory> coinHistoryList = coinHistoryRepository.findByFamily(family.getFamilyId());
+        Page<CoinHistory> coinHistoryPage = coinHistoryRepository.findByFamily(pageable, family.getFamilyId());
 
         //then
+        List<CoinHistory> coinHistoryList = coinHistoryPage.toList();
         for(int i=0; i<coinHistoryList.size()-1; i++){
             assertTrue(coinHistoryList.get(i).getCoinHistoryDate().isAfter(coinHistoryList.get(i+1).getCoinHistoryDate()));
         }

--- a/src/test/java/com/example/onjeong/home/CoinServiceTest.java
+++ b/src/test/java/com/example/onjeong/home/CoinServiceTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -40,6 +43,9 @@ class CoinServiceTest {
 
     @Mock
     private AuthUtil authUtil;
+
+    @Mock
+    private Pageable pageable;
 
     @Nested
     class 코인적립{
@@ -148,12 +154,13 @@ class CoinServiceTest {
             List<CoinHistory> coinHistoryList = new ArrayList<>();
             coinHistoryList.add(CoinHistoryUtils.getRandomCoinHistory(user, CoinHistoryType.RAND, 10));
             coinHistoryList.add(CoinHistoryUtils.getRandomCoinHistory(user, CoinHistoryType.PROFILEIMAGE, 100));
+            final Page<CoinHistory> coinHistoryPage = new PageImpl(coinHistoryList);
 
             doReturn(user).when(authUtil).getUserByAuthentication();
-            doReturn(coinHistoryList).when(coinHistoryRepository).findByFamily(family.getFamilyId());
+            doReturn(coinHistoryPage).when(coinHistoryRepository).findByFamily(pageable, family.getFamilyId());
 
             //when
-            List<CoinHistoryDto> result = coinService.coinHistoryList();
+            List<CoinHistoryDto> result = coinService.coinHistoryList(pageable);
 
             //then
             assertEquals(result.size(), 2);
@@ -175,11 +182,13 @@ class CoinServiceTest {
             for(int i=0; i<11; i++){
                 coinHistoryList.add(CoinHistoryUtils.getRandomCoinHistory(user, CoinHistoryType.RAND, 95));
             }
+            final Page<CoinHistory> coinHistoryPage = new PageImpl(coinHistoryList);
+
             doReturn(user).when(authUtil).getUserByAuthentication();
-            doReturn(coinHistoryList).when(coinHistoryRepository).findByFamily(family.getFamilyId());
+            doReturn(coinHistoryPage).when(coinHistoryRepository).findByFamily(pageable, family.getFamilyId());
 
             //when
-            List<CoinHistoryDto> result = coinService.coinHistoryList();
+            List<CoinHistoryDto> result = coinService.coinHistoryList(pageable);
 
             //then
             assertNotNull(result.get(10).getAfter());


### PR DESCRIPTION
## 개요
코인 적립 내역을 옛날 것까지 확인할 수 있도록 변경하였습니다.

## 작업사항
이때까지 적립된 모든 포인트의 적립 내역을 볼 수 있게 작업하였고, 이 과정에서 적립 내역들을 페이징처리 하였습니다.

## 변경로직
코인 적립 내역을 get 해 올 때, paging 처리 하여 전부 가져오도록 했습니다

### 변경전
3일이 지나면 코인 적립 내역이 모두 사라졌습니다.

### 변경후
코인 적립 내역을 get 해 올 때, paging 처리 하여 전부 가져오도록 했습니다

## 향후목표
꽃 레벨을 10레벨로 조정하고, 랜덤한 꽃이 생성될 때 최대한 겹치지 않도록 하는 로직을 구현 할 예정입니다.