### PR TITLE
refactor: 메일함  paging 사용하도록 변경

### DIFF
--- a/src/main/java/com/example/onjeong/Config/JobConfig.java
+++ b/src/main/java/com/example/onjeong/Config/JobConfig.java
@@ -75,16 +75,16 @@ public class JobConfig {
     public Step mailDeleteStep() {
         return stepBuilderFactory.get("mailDeleteStep")
                 .tasklet((contribution, chunkContext) -> {
-                    List<User> users = userRepository.findAll();
-                    for(User u : users){
-                        List<Mail> validMailReceiveList = mailRepository.findByReceiver(u.getUserId());
-                        List<Mail> validMailSendList = mailRepository.findBySender(u.getUserId());
-                        List<Mail> allMailList = mailRepository.findByUser(u.getUserId());
-                        for(Mail m : allMailList){
-                            if(!validMailReceiveList.contains(m) && !validMailSendList.contains(m))
-                                mailRepository.delete(m);
-                        }
-                    }
+//                    List<User> users = userRepository.findAll();
+//                    for(User u : users){
+//                        List<Mail> validMailReceiveList = mailRepository.findByReceiver(u.getUserId());
+//                        List<Mail> validMailSendList = mailRepository.findBySender(u.getUserId());
+//                        List<Mail> allMailList = mailRepository.findByUser(u.getUserId());
+//                        for(Mail m : allMailList){
+//                            if(!validMailReceiveList.contains(m) && !validMailSendList.contains(m))
+//                                mailRepository.delete(m);
+//                        }
+//                    }
                     return RepeatStatus.FINISHED;
                 })
                 .build();

--- a/src/main/java/com/example/onjeong/mail/controller/MailController.java
+++ b/src/main/java/com/example/onjeong/mail/controller/MailController.java
@@ -13,6 +13,9 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,17 +39,17 @@ public class MailController {
 
     @ApiOperation(value = "받은 메일함 확인")
     @GetMapping("/mailList/receive")
-    public ResponseEntity<ResultResponse> showAllReceiveMail() {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECEIVE_MAIL_SUCCESS, mailService.showAllReceiveMail()));
+    public ResponseEntity<ResultResponse> showAllReceiveMail(@PageableDefault(size=20, sort = "mail_id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECEIVE_MAIL_SUCCESS, mailService.showAllReceiveMail(pageable)));
     }
 
     @ApiOperation(value = "보낸 메일함 확인")
     @GetMapping("/mailList/send")
-    public ResponseEntity<ResultResponse> showAllSendMail() {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_SEND_MAIL_SUCCESS, mailService.showAllSendMail()));
+    public ResponseEntity<ResultResponse> showAllSendMail(@PageableDefault(size=20, sort = "mail_id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_SEND_MAIL_SUCCESS, mailService.showAllSendMail(pageable)));
     }
 
-    @ApiOperation(value = "특정 메일 확인")
+    @ApiOperation(value = "특정 메일 읽음 처리")
     @GetMapping("/mails/{mailId}")
     public ResponseEntity<ResultResponse> showMail(@PathVariable("mailId") Long mailId) {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ONE_MAIL_SUCCESS, mailService.showOneMail(mailId)));

--- a/src/main/java/com/example/onjeong/mail/repository/MailRepository.java
+++ b/src/main/java/com/example/onjeong/mail/repository/MailRepository.java
@@ -3,6 +3,8 @@ package com.example.onjeong.mail.repository;
 import com.example.onjeong.mail.domain.Mail;
 import com.example.onjeong.question.domain.Question;
 import com.example.onjeong.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,13 +20,13 @@ public interface MailRepository extends JpaRepository<Mail, Long> {
 
     @Query(nativeQuery = true,
             value="SELECT * FROM mail m WHERE m.receiver_id = :id AND m.receiver_delete = false" +
-            " ORDER BY m.send_time DESC LIMIT 30")
-    List<Mail> findByReceiver(@Param("id") Long id);
+            " ORDER BY m.mail_id DESC")
+    Page<Mail> findByReceiver(Pageable pageable, @Param("id") Long id);
 
     @Query(nativeQuery = true,
             value="SELECT * FROM mail m WHERE m.sender_id = :id AND m.sender_delete = false" +
-            " ORDER BY m.send_time DESC LIMIT 30")
-    List<Mail> findBySender(@Param("id") Long id);
+            " ORDER BY m.mail_id DESC")
+    Page<Mail> findBySender(Pageable pageable, @Param("id") Long id);
 
     @Query("SELECT m FROM Mail m WHERE m.receiverWantDelete = true AND m.senderWantDelete = true")
     List<Mail> findDeleteMail();

--- a/src/main/java/com/example/onjeong/mail/service/MailService.java
+++ b/src/main/java/com/example/onjeong/mail/service/MailService.java
@@ -15,6 +15,7 @@ import com.example.onjeong.user.repository.UserRepository;
 import com.example.onjeong.util.AuthUtil;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -52,9 +53,9 @@ public class MailService {
     }
 
     // 받은 메일함 확인
-    public List<MailDto> showAllReceiveMail(){
+    public List<MailDto> showAllReceiveMail(Pageable pageable){
         User user = authUtil.getUserByAuthentication();
-        List<Mail> mailList = mailRepository.findByReceiver(user.getUserId());
+        List<Mail> mailList = mailRepository.findByReceiver(pageable, user.getUserId()).toList();
         List<MailDto> mailDtoList = new ArrayList<>();
 
         for(Mail m : mailList){
@@ -71,9 +72,9 @@ public class MailService {
     }
 
     // 보낸 메일함 확인
-    public List<MailDto> showAllSendMail(){
+    public List<MailDto> showAllSendMail(Pageable pageable){
         User user = authUtil.getUserByAuthentication();
-        List<Mail> mailList = mailRepository.findBySender(user.getUserId());
+        List<Mail> mailList = mailRepository.findBySender(pageable, user.getUserId()).toList();
         List<MailDto> mailDtoList = new ArrayList<>();
 
         for(Mail m : mailList){

--- a/src/test/java/com/example/onjeong/mail/MailRepositoryTest.java
+++ b/src/test/java/com/example/onjeong/mail/MailRepositoryTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
@@ -45,18 +47,18 @@ class MailRepositoryTest {
     }
 
     @Test
-    @DisplayName("받은메일함 조회 시 최신순으로 최대 30개의 메일만 조회 되는지 확인")
     void 받은메일함확인() {
         //given
         final Family family = FamilyUtils.getRandomFamily();
         final User user = UserUtils.getRandomUser(family);
+        final Pageable pageable = PageRequest.of(0, 20);
 
         // when
-        List<Mail> result = mailRepository.findByReceiver(user.getUserId());
+        List<Mail> result = mailRepository.findByReceiver(pageable, user.getUserId()).toList();
 
         // then
         // 리스트 갯수가 30 이하인지
-        assertThat(result.size(),  lessThanOrEqualTo(30));
+        assertThat(result.size(),  lessThanOrEqualTo(20));
         for(Mail m : result){
             // 받는 사람이 정확한지
             assertEquals(user.getUserId(), m.getReceiveUser().getUserId());
@@ -71,18 +73,17 @@ class MailRepositoryTest {
     }
 
     @Test
-    @DisplayName("보낸메일함 조회 시 최신순으로 최대 30개의 메일만 조회 되는지 확인")
     void 보낸메일함확인() {
         //given
         final Family family = FamilyUtils.getRandomFamily();
         final User user = UserUtils.getRandomUser(family);
-
+        final Pageable pageable = PageRequest.of(0, 20);
         // when
-        List<Mail> result = mailRepository.findBySender(user.getUserId());
+        List<Mail> result = mailRepository.findBySender(pageable, user.getUserId()).toList();
 
         // then
         // 리스트 갯수가 30 이하인지
-        assertThat(result.size(),  lessThanOrEqualTo(30));
+        assertThat(result.size(),  lessThanOrEqualTo(20));
         for(Mail m : result){
             // 받는 사람이 정확한지
             assertEquals(user.getUserId(), m.getSendUser().getUserId());

--- a/src/test/java/com/example/onjeong/mail/MailServiceTest.java
+++ b/src/test/java/com/example/onjeong/mail/MailServiceTest.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.*;
 
@@ -38,6 +41,9 @@ class MailServiceTest {
 
     @Mock
     private MailRepository mailRepository;
+
+    @Mock
+    private Pageable pageable;
 
     @Test
     void 메일전송() throws FirebaseMessagingException {
@@ -72,11 +78,12 @@ class MailServiceTest {
             final Mail mail = MailUtils.getRandomMail(user2, user);
             mailList.add(mail);
         }
+        final Page<Mail> mailPage = new PageImpl(mailList);
         doReturn(user).when(authUtil).getUserByAuthentication();
-        doReturn(mailList).when(mailRepository).findByReceiver(user.getUserId());
+        doReturn(mailPage).when(mailRepository).findByReceiver(pageable, user.getUserId());
 
         //when
-        List<MailDto> result = mailService.showAllReceiveMail();
+        List<MailDto> result = mailService.showAllReceiveMail(pageable);
 
         //then
         assertEquals(result.size(), 3);
@@ -97,11 +104,12 @@ class MailServiceTest {
             final Mail mail = MailUtils.getRandomMail(user, user2);
             mailList.add(mail);
         }
+        final Page<Mail> mailPage = new PageImpl(mailList);
         doReturn(user).when(authUtil).getUserByAuthentication();
-        doReturn(mailList).when(mailRepository).findByReceiver(user.getUserId());
+        doReturn(mailPage).when(mailRepository).findBySender(pageable, user.getUserId());
 
         //when
-        List<MailDto> result = mailService.showAllReceiveMail();
+        List<MailDto> result = mailService.showAllSendMail(pageable);
 
         //then
         assertEquals(result.size(), 3);


### PR DESCRIPTION
## 개요
받은 메일함/ 보낸 메일함을 옛날 것까지 확인할 수 있도록 변경하였습니다.

## 작업사항
이때까지 주고받은 모든 메일을 볼 수 있게 작업하였고, 이 과정에서 보낸 메일함/받은 메일함을 페이징처리 하였습니다.

## 변경로직
메일을 get 해 올 때, paging 처리 하여 전부 가져오도록 했습니다

### 변경전
최대 30개의 메일을 확인할 수 있었습니다.

### 변경후
메일을 get 해 올 때, paging 처리 하여 전부 가져오도록 했습니다

## 향후목표
만개하여 다시 꽃 생성 시 최대한 중복되지 않는 꽃 종류가 생성 될 수 있도록 코드 수정 할 예정입니다.