### PR TITLE
feat : WebRestController 추가

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/infra/WebRestController.java
+++ b/module-api/src/main/java/com/example/onjeong/infra/WebRestController.java
@@ -1,0 +1,30 @@
+package com.example.onjeong.infra;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class WebRestController {
+
+    private final Environment env;
+
+    @GetMapping("/current-profile")
+    public String getProfile () {
+        List<String> profiles = Arrays.asList(env.getActiveProfiles());
+        List<String> realProfiles = Arrays.asList("server", "server1", "server2");
+
+        String defaultProfile = profiles.isEmpty() ? "default" : profiles.get(0);
+
+        return profiles.stream()
+                .filter(realProfiles::contains)
+                .findAny()
+                .orElse(defaultProfile);
+    }
+}


### PR DESCRIPTION
## 개요
서버 부하를 덜어주기 위해 nginx를 통해 WAS서버를 분리하는 작업을 수행했습니다.
WAS는 2대로 구성했으며 현재 작업중인 서버를 확인하기 위해 WebRestController를 추가했습니다.

## 작업사항
WebRestController에는 '/current-profile' api를 호출하면 현재 작업중인 서버 이름을 반환해주는 로직을 구현해놨습니다.

## 변경로직
getProfile함수를 통해 현재 작업중인 서버 이름을 반환합니다.

### 변경전
nginx를 사용하지 않아 WebRestController가 존재하지 않았습니다.

### 변경후
nginx를 도입해서 현재 작업중인 서버이름을 반환해주는 WebRestController를 추가했습니다.