### PR TITLE
feat: 회원가입 시 질문 자동생성 기능 추가

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
+++ b/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
@@ -15,7 +15,11 @@ import com.example.onjeong.home.domain.FlowerColor;
 import com.example.onjeong.home.domain.FlowerKind;
 import com.example.onjeong.home.repository.FlowerRepository;
 
+import com.example.onjeong.question.domain.PureQuestion;
+import com.example.onjeong.question.domain.Question;
 import com.example.onjeong.question.repository.AnswerRepository;
+import com.example.onjeong.question.repository.PureQuestionRepository;
+import com.example.onjeong.question.repository.QuestionRepository;
 import com.example.onjeong.user.Auth.TokenUtils;
 import com.example.onjeong.user.domain.*;
 import com.example.onjeong.family.repository.FamilyRepository;
@@ -35,6 +39,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,6 +52,8 @@ public class UserService {
     private final FamilyRepository familyRepository;
     private final ProfileRepository profileRepository;
     private final FlowerRepository flowerRepository;
+    private final QuestionRepository questionRepository;
+    private final PureQuestionRepository pureQuestionRepository;
     private final AnswerRepository answerRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
@@ -86,6 +93,14 @@ public class UserService {
                 .family(savedFamily)
                 .build();
         flowerRepository.save(newFlower);
+
+        final PureQuestion pureQuestion = pureQuestionRepository.chooseWeeklyQuestion();
+        final Question newQuestion = Question.builder()
+                .questionTime(LocalDateTime.now())
+                .questionContent(pureQuestion.getPureQuestionContent())
+                .family(family)
+                .build();
+        questionRepository.save(newQuestion);
     }
 
     //가족회원이 있는 회원 가입


### PR DESCRIPTION
## 개요
회원가입 시 자동으로 그 주의 문답 1개를 생성하도록 했습니다.

## 작업사항
새로 신규 가입한 회원은 다음주 질문이 생성될 때까지 가족 문답 질문을 가질 수 없었기 때문에, 회원가입 시 자동으로 그 주의 문답 1개를 생성하도록 했습니다.

## 변경로직
가족 회원이 없는 최원가입 로직을 수정했습니다.

### 변경전
새로 신규 가입한 회원은 다음주 질문이 생성될 때까지 가족 문답 질문을 가질 수 없었습니다.

### 변경후
회원가입 시 자동으로 그 주의 문답 1개를 생성하도록 했습니다.

## 향후목표
없음