### PR TITLE
refactor : 월별 모든 특수일정 가져오는 메소드 반환타입 변경

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/anniversary/controller/AnniversaryController.java
+++ b/module-api/src/main/java/com/example/onjeong/anniversary/controller/AnniversaryController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
 
 @Api(tags="Anniversary")
@@ -27,7 +28,7 @@ public class AnniversaryController {
     @ApiOperation(value="월별 모든 특수일정 가져오기")
     @GetMapping(value = "/months/anniversaries/{anniversaryDate}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> getAllAnniversaryOfMonth(@PathVariable("anniversaryDate") String anniversaryDate){
-        List<AnniversaryDto> data= anniversaryService.getAllAnniversaryOfMonth(LocalDate.parse(anniversaryDate, DateTimeFormatter.ISO_DATE));
+        HashMap<LocalDate,List<AnniversaryDto>> data= anniversaryService.getAllAnniversaryOfMonth(LocalDate.parse(anniversaryDate, DateTimeFormatter.ISO_DATE));
         return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ALL_ANNIVERSARY_SUCCESS,data));
     }
 

--- a/module-api/src/main/java/com/example/onjeong/anniversary/service/AnniversaryService.java
+++ b/module-api/src/main/java/com/example/onjeong/anniversary/service/AnniversaryService.java
@@ -27,24 +27,26 @@ public class AnniversaryService {
 
     //월별 모든 특수일정 가져오기
     @Transactional(readOnly = true)
-    public List<AnniversaryDto> getAllAnniversaryOfMonth(final LocalDate anniversaryDate){
+    public HashMap<LocalDate,List<AnniversaryDto>> getAllAnniversaryOfMonth(final LocalDate anniversaryDate){
         final User loginUser= authUtil.getUserByAuthentication();
         final Family family= loginUser.getFamily();
 
         LocalDate start= anniversaryDate.withDayOfMonth(1);
         final LocalDate end= anniversaryDate.withDayOfMonth(anniversaryDate.lengthOfMonth());
 
-        final List<AnniversaryDto> result= new ArrayList<>();
+        final HashMap<LocalDate,List<AnniversaryDto>> result= new HashMap<>();
         while(!start.isAfter(end)){
+            final List<AnniversaryDto> anniversaryDtoList= new ArrayList<>();
+
             for(Anniversary a:anniversaryRepository.findByAnniversaryDate(start,family.getFamilyId())){
                 final AnniversaryDto anniversaryDto= AnniversaryDto.builder()
                         .anniversaryId(a.getAnniversaryId())
                         .anniversaryContent(a.getAnniversaryContent())
                         .anniversaryType(a.getAnniversaryType())
-                        .anniversaryDate(a.getAnniversaryDate())
                         .build();
-                result.add(anniversaryDto);
+                anniversaryDtoList.add(anniversaryDto);
             }
+            if(anniversaryDtoList.size()>0) result.put(start, anniversaryDtoList);
             start= start.plus(1, ChronoUnit.DAYS);
         }
 
@@ -63,7 +65,6 @@ public class AnniversaryService {
                     .anniversaryId(a.getAnniversaryId())
                     .anniversaryContent(a.getAnniversaryContent())
                     .anniversaryType(a.getAnniversaryType())
-                    .anniversaryDate(a.getAnniversaryDate())
                     .build();
             result.add(anniversaryDto);
         }

--- a/module-common/src/main/java/com/example/onjeong/anniversary/dto/AnniversaryDto.java
+++ b/module-common/src/main/java/com/example/onjeong/anniversary/dto/AnniversaryDto.java
@@ -16,5 +16,4 @@ public class AnniversaryDto {
     private Long anniversaryId;
     private String anniversaryContent;
     private AnniversaryType anniversaryType;
-    private LocalDate anniversaryDate;
 }


### PR DESCRIPTION
## 개요
프론트엔드 분의 요청사항(데이터 반환타입 수정)을 작업했습니다.

## 작업사항
- 기념일에서 월별 모든 특수일정 가져오는 메소드의 반환타입을 수정했습니다.
- 변경된 사항에 맞게 테스트 작업도 수행했습니다.

## 변경로직
반환타입이 List -> Map 으로 수정됐습니다.

### 변경전
List<AnniversaryDto> getAllAnniversaryOfMonth(final LocalDate anniversaryDate)

### 변경후
HashMap<LocalDate,List<AnniversaryDto>> getAllAnniversaryOfMonth(final LocalDate anniversaryDate)

## 기타
수정사항을 반영하기 위해 바로 머지합니다!