### PR TITLE
refactor : 암호화 인터페이스 변경

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
+++ b/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
@@ -35,7 +35,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,7 +55,7 @@ public class UserService {
     private final QuestionRepository questionRepository;
     private final PureQuestionRepository pureQuestionRepository;
     private final AnswerRepository answerRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
     private final S3Uploader s3Uploader;
     private final AuthUtil authUtil;

--- a/module-api/src/test/java/com/example/onjeong/user/UserServiceTest.java
+++ b/module-api/src/test/java/com/example/onjeong/user/UserServiceTest.java
@@ -1,14 +1,11 @@
 package com.example.onjeong.user;
 
-import com.example.onjeong.S3.S3Uploader;
-import com.example.onjeong.board.repository.BoardRepository;
 import com.example.onjeong.family.domain.Family;
 import com.example.onjeong.family.repository.FamilyRepository;
 import com.example.onjeong.home.domain.Flower;
 import com.example.onjeong.home.repository.FlowerRepository;
 import com.example.onjeong.profile.domain.Profile;
 import com.example.onjeong.profile.repository.ProfileRepository;
-import com.example.onjeong.question.repository.AnswerRepository;
 import com.example.onjeong.user.domain.User;
 import com.example.onjeong.user.dto.*;
 import com.example.onjeong.user.repository.UserRepository;
@@ -23,7 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -51,16 +48,7 @@ public class UserServiceTest {
     private AuthUtil authUtil;
 
     @Mock
-    private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private BoardRepository boardRepository;
-
-    @Mock
-    private AnswerRepository answerRepository;
-
-    @Mock
-    private S3Uploader s3Uploader;
+    private BCryptPasswordEncoder passwordEncoder;
 
     @Mock
     private FlowerRepository flowerRepository;

--- a/module-common/src/main/java/com/example/onjeong/Config/SecurityConfig.java
+++ b/module-common/src/main/java/com/example/onjeong/Config/SecurityConfig.java
@@ -86,7 +86,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
-    public BCryptPasswordEncoder passwordEncoder(){  //회원가입시 비밀번호 암호화에 사용할 Encoder를 빈에 등록
+    public BCryptPasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
     }
 


### PR DESCRIPTION
## 개요
비밀번호를 암호화할때는 BCryptPasswordEncoder 방식을 사용하는 것을 권장한다고 하여, PasswordEncoder를 BCryptPasswordEncoder로 수정했습니다.
기존에 사용했던 PasswordEncoder는 단방향 암호화방식이라면, BCryptPasswordEncoder는 BCrypt 해시 함수와 랜덤의 salt가 사용된 방식입니다.

## 작업사항
- 암호화 인터페이스 변경
- 불필요한 주석 제거

## 변경로직
비밀번호 암호화 하는 부분은 PasswordEncoder -> BCryptPasswordEncoder 로 수정했습니다.

### 변경전
PasswordEncoder passwordEncoder;

### 변경후
BCryptPasswordEncoder passwordEncoder;