### PR TITLE
refactor : 로그아웃 기능 리팩토링

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/profile/service/ProfileService.java
+++ b/module-api/src/main/java/com/example/onjeong/profile/service/ProfileService.java
@@ -41,6 +41,7 @@ public class ProfileService {
             final AllUserOfFamilyDto allUserOfFamilyDto = AllUserOfFamilyDto.builder()
                     .userId(u.getUserId())
                     .userStatus(u.getUserStatus())
+                    .profileImageUrl(u.getProfile().getProfileImageUrl())
                     .build();
             result.add(allUserOfFamilyDto);
         }

--- a/module-api/src/main/java/com/example/onjeong/user/controller/UserController.java
+++ b/module-api/src/main/java/com/example/onjeong/user/controller/UserController.java
@@ -81,7 +81,7 @@ public class UserController {
     }
 
     @ApiOperation(value="기본 홈")
-    @GetMapping(value="/home", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value="/home", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> getHome (){
         return ResponseEntity.ok(ResultResponse.of(ResultCode.LOGOUT_SUCCESS));
     }

--- a/module-common/src/main/java/com/example/onjeong/Config/SecurityConfig.java
+++ b/module-common/src/main/java/com/example/onjeong/Config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .logout()
                 .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-                .logoutSuccessHandler((request, response, authentication) -> response.sendRedirect("/home"))
+                .logoutSuccessHandler((request, response, authentication) -> request.getRequestDispatcher("/home").forward(request, response))
                 .invalidateHttpSession(true);
     }
 

--- a/module-common/src/main/java/com/example/onjeong/profile/dto/AllUserOfFamilyDto.java
+++ b/module-common/src/main/java/com/example/onjeong/profile/dto/AllUserOfFamilyDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class AllUserOfFamilyDto {
     private  Long userId;
     private String userStatus;
+    private String profileImageUrl;
 }


### PR DESCRIPTION
## 개요
프론트엔드분의 요청사항을 반영했습니다.


## 작업사항
- 가족구성원 목록을 반환할때, 구성원의 프로필사진 url도 포함해서 반환하도록 수정했습니다.
- 로그아웃 성공시 수행되는 작업을 리팩토링 했습니다.
   - 로그아웃 성공시 '/home' api로 리다이렉션했을 경우, https와 포트번호가 일치하지 않아 요청이 제대로 수행되지 않았습니다.
   - 이를 해결하기 위해 '/home' api로 포워드해서 클라이언트로 요청이 가지 않도록 구현했습니다.


## 변경로직
- 가족구성원 목록을 반환하는 dto에 프로필사진 url 필드를 추가했습니다.
- 로그아웃에 성공하면 '/home' api로 포워드하도록 구현했습니다.


### 변경전
- AllUserOfFamilyDto에 profileImageUrl필드가 없습니다.
- 로그아웃 성공시 '/home' api로 리다이렉션했습니다.

### 변경후
- AllUserOfFamilyDto에 profileImageUrl필드가 있습니다.
- 로그아웃 성공시 '/home' api로 포워드했습니다.


## 사용방법
- 스웨거 또는 포스트맨으로 테스트할 수 있습니다.