### PR TITLE
feat : 알림 목록 시 필드 추가

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/notification/service/NotificationService.java
+++ b/module-api/src/main/java/com/example/onjeong/notification/service/NotificationService.java
@@ -18,10 +18,14 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.jni.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,8 +54,16 @@ public class NotificationService {
         List<Notifications> notificationsList = notificationRepository.findAllByUserId(user.getUserId());
         List<NotificationDto> notificationDtoList = new ArrayList<>();
         for(Notifications n : notificationsList){
+
+            Long days = ChronoUnit.DAYS.between(n.getNotificationTime(), LocalDateTime.now());
+            Long hours = ChronoUnit.HOURS.between(n.getNotificationTime(), LocalDateTime.now());
+            Long minutes = ChronoUnit.SECONDS.between(n.getNotificationTime(), LocalDateTime.now())/60;
+
+            String notificationTime = days != 0 ? days.toString() + "일전" : hours != 0  ? hours.toString() + "시간전" : minutes.toString() + "분전";
+
             notificationDtoList.add(NotificationDto.builder()
                     .notificationContent(n.getNotificationContent())
+                    .notificationTime(notificationTime)
                     .build());
         }
         return notificationDtoList;

--- a/module-common/src/main/java/com/example/onjeong/notification/dto/NotificationDto.java
+++ b/module-common/src/main/java/com/example/onjeong/notification/dto/NotificationDto.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NotificationDto {
     private String notificationContent;
+    private String notificationTime;
 }


### PR DESCRIPTION
## 개요
프론트엔드분의 요청사항을 반영했습니다.


## 작업사항
- 알림 목록을 반환할때, 알림 온 시간이 현재 시간으로부터 몇 분 전인지도 포함해서 반환하도록 수정했습니다.

## 변경로직
- 알림 목록을 반환하는 dto에 알람시간 관련 필드를 추가했습니다.
- 현재 시간과 알림 생성 시간 사이의 차를 계산 해 반환하도록 했습니다.

## 사용방법
- 스웨거 또는 포스트맨으로 테스트할 수 있습니다.