### PR TITLE
refactor : 질문, 답변 보여주기 방식 변경

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/question/controller/QuestionController.java
+++ b/module-api/src/main/java/com/example/onjeong/question/controller/QuestionController.java
@@ -29,14 +29,14 @@ public class QuestionController {
 
     @ApiOperation(value = "이주의 문답 질문 보여주기")
     @GetMapping("/questions")
-    public ResponseEntity<ResultResponse> showQuestion(@PageableDefault(size=20, sort = "questionId", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_QUESTION_SUCCESS, questionService.showQuestion(pageable)));
+    public ResponseEntity<ResultResponse> showQuestion() {
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_QUESTION_SUCCESS, questionService.showWeeklyQuestion()));
     }
 
     @ApiOperation(value = "이주의 문답 답변들 보여주기")
     @GetMapping("/answers/{questionId}")
     public ResponseEntity<ResultResponse> showAllAnswer(@PathVariable("questionId") Long questionId) {
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ANSWERS_SUCCESS, questionService.showAllAnswer(questionId)));
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ANSWERS_SUCCESS, questionService.showWeeklyAnswer()));
     }
 
     @ApiOperation(value = "이주의 문답에 답변한 가족 리스트")

--- a/module-api/src/main/java/com/example/onjeong/question/service/QuestionService.java
+++ b/module-api/src/main/java/com/example/onjeong/question/service/QuestionService.java
@@ -31,6 +31,40 @@ public class QuestionService {
     private final AnswerRepository answerRepository;
     private final AuthUtil authUtil;
 
+    public QuestionDto showWeeklyQuestion(){
+        User user = authUtil.getUserByAuthentication();
+        Question question = questionRepository.findWeeklyQuestion(user.getFamily().getFamilyId());
+        if(question == null){ // 서버에 준비된 이주의 질문 내용이 없는 경우
+            throw new NullQuestionException("weekly question not exist", ErrorCode.QUESTION_NOTEXIST);
+        }
+        QuestionDto questionDto = QuestionDto.builder()
+                .questonId(question.getQuestionId())
+                .questionContent(question.getQuestionContent())
+                .build();
+        return questionDto;
+    }
+
+    public List<AnswerDto> showWeeklyAnswer(){
+        User user = authUtil.getUserByAuthentication();
+        Question question = questionRepository.findWeeklyQuestion(user.getFamily().getFamilyId());
+        if(question == null){ // 서버에 준비된 이주의 질문 내용이 없는 경우
+            throw new NullQuestionException("weekly question not exist", ErrorCode.QUESTION_NOTEXIST);
+        }
+        List<Answer> answers = answerRepository.findByQuestion(question);
+        List<AnswerDto> answerDtos = new ArrayList<>();
+        for(Answer a : answers){
+            AnswerDto answer = AnswerDto.builder()
+                    .answerId(a.getAnswerId())
+                    .userName(a.getUser().getUserName())
+                    .answerContent(a.getAnswerContent())
+                    .answerTime(a.getAnswerTime())
+                    .build();
+            answerDtos.add(answer);
+        }
+        return answerDtos;
+    }
+
+
     public List<QuestionDto> showQuestion(Pageable pageable){
         User user = authUtil.getUserByAuthentication();
 


### PR DESCRIPTION
## 개요
프론트엔드분의 요청사항을 반영했습니다.

## 작업사항
- 질문을 이 주의 질문 1개만 보여주도록 변경했습니다.
- 답변도 questionId 없이도 이 주의 질문에 대한 답변만 확인할 수 있도록 수정했습니다.

## 변경로직
- 질문, 답변 보여주기 함수에 파라미터를 없애고 sql문을 통해 이주의 질문, 답변만 가져오도록 수정했습니다.

## 기타
- 추후 질문 목록 형태로 변경 될 수 있어 service 파일에 기존의 코드도 남겨두었습니다.