### PR TITLE
feat : 자기소개타입 enum 추가

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/profile/controller/ProfileController.java
+++ b/module-api/src/main/java/com/example/onjeong/profile/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.example.onjeong.notification.service.NotificationService;
 import com.example.onjeong.coin.domain.CoinHistoryType;
 import com.example.onjeong.coin.service.CoinService;
 import com.example.onjeong.profile.domain.Profile;
+import com.example.onjeong.profile.domain.SelfIntroductionType;
 import com.example.onjeong.profile.dto.*;
 import com.example.onjeong.profile.service.ProfileService;
 import com.example.onjeong.result.ResultCode;
@@ -116,9 +117,9 @@ public class ProfileController {
     public ResponseEntity<ResultResponse> registerProfileFavorite(@PathVariable("userId") Long userId
             , @RequestBody SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto) throws FirebaseMessagingException{
 
-        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "favorite"));
+        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.FAVORITE));
         else{
-            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "favorite"));
+            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.FAVORITE));
             coinService.coinSave(CoinHistoryType.PROFILEFAV, 100);
         }
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_FAVORITE_SUCCESS));
@@ -127,7 +128,7 @@ public class ProfileController {
     @ApiOperation(value="좋아하는 것 삭제하기")
     @DeleteMapping(value = "/profiles/favorites/{userId}/{selfIntroductionAnswerId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> deleteProfileFavorite(@PathVariable("userId") Long userId, @PathVariable("selfIntroductionAnswerId") Long selfIntroductionAnswerId) {
-        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, "favorite");
+        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, SelfIntroductionType.FAVORITE);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_FAVORITE_SUCCESS));
     }
 
@@ -136,9 +137,9 @@ public class ProfileController {
     public ResponseEntity<ResultResponse> registerProfileHate(@PathVariable("userId") Long userId
             , @RequestBody SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto) throws FirebaseMessagingException{
 
-        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "hate"));
+        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.HATE));
         else{
-            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "hate"));
+            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.HATE));
             coinService.coinSave(CoinHistoryType.PROFILEHATE, 100);
         }
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_HATE_SUCCESS));
@@ -147,7 +148,7 @@ public class ProfileController {
     @ApiOperation(value="싫어하는 것 삭제하기")
     @DeleteMapping(value = "/profiles/hates/{userId}/{selfIntroductionAnswerId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> deleteProfileHate(@PathVariable("userId") Long userId, @PathVariable("selfIntroductionAnswerId") Long selfIntroductionAnswerId) {
-        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, "hate");
+        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, SelfIntroductionType.HATE);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_HATE_SUCCESS));
     }
 
@@ -156,9 +157,9 @@ public class ProfileController {
     public ResponseEntity<ResultResponse> registerProfileExpression(@PathVariable("userId") Long userId
             , @RequestBody SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto) throws FirebaseMessagingException{
 
-        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "expression"));
+        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.EXPRESSION));
         else{
-            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "expression"));
+            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.EXPRESSION));
             coinService.coinSave(CoinHistoryType.PROFILEEXPRESSION, 100);
         }
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_EXPRESSION_SUCCESS));
@@ -167,7 +168,7 @@ public class ProfileController {
     @ApiOperation(value="한단어로 표현하는 것 삭제하기")
     @DeleteMapping(value = "/profiles/expressions/{userId}/{selfIntroductionAnswerId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> deleteProfileExpression(@PathVariable("userId") Long userId, @PathVariable("selfIntroductionAnswerId") Long selfIntroductionAnswerId) {
-        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, "expression");
+        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, SelfIntroductionType.EXPRESSION);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_EXPRESSION_SUCCESS));
     }
 
@@ -176,9 +177,9 @@ public class ProfileController {
     public ResponseEntity<ResultResponse> registerProfileInterest(@PathVariable("userId") Long userId
             , @RequestBody SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto) throws FirebaseMessagingException{
 
-        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "interest"));
+        if(profileService.checkProfileUpload()) notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.INTEREST));
         else{
-            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, "interest"));
+            notificationService.sendProfileModify(profileService.registerSelfIntroductionAnswer(userId, selfIntroductionAnswerRegisterDto, SelfIntroductionType.INTEREST));
             coinService.coinSave(CoinHistoryType.PROFILEINTEREST, 100);
         }
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_INTEREST_SUCCESS));
@@ -187,7 +188,7 @@ public class ProfileController {
     @ApiOperation(value="관심사 삭제하기")
     @DeleteMapping(value = "/profiles/interests/{userId}/{selfIntroductionAnswerId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> deleteProfileInterest(@PathVariable("userId") Long userId, @PathVariable("selfIntroductionAnswerId") Long selfIntroductionAnswerId) {
-        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, "interest");
+        profileService.deleteSelfIntroductionAnswer(userId, selfIntroductionAnswerId, SelfIntroductionType.INTEREST);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_INTEREST_SUCCESS));
     }
 }

--- a/module-api/src/main/java/com/example/onjeong/profile/service/ProfileService.java
+++ b/module-api/src/main/java/com/example/onjeong/profile/service/ProfileService.java
@@ -135,32 +135,32 @@ public class ProfileService {
 
     //자기소개 답변 작성하기
     @Transactional
-    public Profile registerSelfIntroductionAnswer(final Long userId, final SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto, final String category){
+    public Profile registerSelfIntroductionAnswer(final Long userId, final SelfIntroductionAnswerRegisterDto selfIntroductionAnswerRegisterDto, final SelfIntroductionType category){
         final User user= authUtil.getUserByUserId(userId);
         final Profile profile= profileUtil.getProfileByUser(user);
         switch(category){
-            case "favorite":
+            case FAVORITE:
                 final Favorite favorite= Favorite.builder()
                         .favoriteContent(selfIntroductionAnswerRegisterDto.getSelfIntroductionAnswerContent())
                         .profile(profile)
                         .build();
                 favoriteRepository.save(favorite);
                 break;
-            case "hate":
+            case HATE:
                 final Hate hate= Hate.builder()
                         .hateContent(selfIntroductionAnswerRegisterDto.getSelfIntroductionAnswerContent())
                         .profile(profile)
                         .build();
                 hateRepository.save(hate);
                 break;
-            case "expression":
+            case EXPRESSION:
                 final Expression expression= Expression.builder()
                         .expressionContent(selfIntroductionAnswerRegisterDto.getSelfIntroductionAnswerContent())
                         .profile(profile)
                         .build();
                 expressionRepository.save(expression);
                 break;
-            case "interest":
+            case INTEREST:
                 final Interest interest= Interest.builder()
                         .interestContent(selfIntroductionAnswerRegisterDto.getSelfIntroductionAnswerContent())
                         .profile(profile)
@@ -174,20 +174,20 @@ public class ProfileService {
 
     //자기소개 답변 삭제하기
     @Transactional
-    public void deleteSelfIntroductionAnswer(final Long userId, final Long selfIntroductionAnswerId, final String category){
+    public void deleteSelfIntroductionAnswer(final Long userId, final Long selfIntroductionAnswerId, final SelfIntroductionType category){
         final User user= authUtil.getUserByUserId(userId);
         final Profile profile= profileUtil.getProfileByUser(user);
         switch(category){
-            case "favorite":
+            case FAVORITE:
                 favoriteRepository.deleteByFavoriteIdAndProfile(selfIntroductionAnswerId, profile);
                 break;
-            case "hate":
+            case HATE:
                 hateRepository.deleteByHateIdAndProfile(selfIntroductionAnswerId, profile);
                 break;
-            case "expression":
+            case EXPRESSION:
                 expressionRepository.deleteByExpressionIdAndProfile(selfIntroductionAnswerId, profile);
                 break;
-            case "interest":
+            case INTEREST:
                 interestRepository.deleteByInterestIdAndProfile(selfIntroductionAnswerId, profile);
                 break;
         }

--- a/module-api/src/test/java/com/example/onjeong/profile/ProfileServiceTest.java
+++ b/module-api/src/test/java/com/example/onjeong/profile/ProfileServiceTest.java
@@ -273,7 +273,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, "favorite");
+                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, SelfIntroductionType.FAVORITE);
 
 
                 //then
@@ -297,7 +297,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, "hate");
+                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, SelfIntroductionType.HATE);
 
 
                 //then
@@ -321,7 +321,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, "expression");
+                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, SelfIntroductionType.EXPRESSION);
 
 
                 //then
@@ -345,7 +345,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, "interest");
+                profileService.registerSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerRegisterDto, SelfIntroductionType.INTEREST);
 
 
                 //then
@@ -369,7 +369,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, "favorite");
+                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, SelfIntroductionType.FAVORITE);
 
 
                 //then
@@ -389,7 +389,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, "hate");
+                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, SelfIntroductionType.HATE);
 
 
                 //then
@@ -409,7 +409,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, "expression");
+                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, SelfIntroductionType.EXPRESSION);
 
 
                 //then
@@ -429,7 +429,7 @@ public class ProfileServiceTest {
 
 
                 //when
-                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, "interest");
+                profileService.deleteSelfIntroductionAnswer(user.getUserId(), selfIntroductionAnswerId, SelfIntroductionType.INTEREST);
 
 
                 //then

--- a/module-common/src/main/java/com/example/onjeong/profile/domain/SelfIntroductionType.java
+++ b/module-common/src/main/java/com/example/onjeong/profile/domain/SelfIntroductionType.java
@@ -1,0 +1,15 @@
+package com.example.onjeong.profile.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SelfIntroductionType {
+    EXPRESSION("EXPRESSION"),
+    FAVORITE("FAVORITE"),
+    HATE("HATE"),
+    INTEREST("INTEREST");
+
+    private final String value;
+}


### PR DESCRIPTION
## 개요
프로필 자기소개 종류(favorite, hate, expression, interest)를 enum클래스에 정리했습니다.
자기소개 종류가 추후에 추가 될 수 있기 때문에 확장성 측면에서 enum클래스를 사용하는 것이 좋을 것 같다 판단했습니다. 그리고 작업할 때 일일히 string으로 적었던 것을 enum으로 정의하면  코드적 실수를 줄일 수 있기 때문에 enum을 추가했습니다.

## 작업사항
1. 자기소개 타입을 나타내는 enum클래스 추가
2. 함수 파라미터 타입 변경

## 변경로직
1. SelfIntroductionType enum클래스 추가
3. 함수 파라미터에서 string category로 정의했던 부분을 SelfIntroductionType category로 수정했습니다. 변경된 부분에 대해 테스트 작업도 수행했습니다.

### 변경전
자기소개 종류를 구분할 때 string타입으로 구분했었습니다.

### 변경후
자기소개 종류를 구분할 때 SelfIntroductionType타입으로 구분했습니다.

## 기타
추후에 디바이스 기기를 통한 테스트 작업을 수행할 계획입니다.