### PR TITLE
refactor : dto 변수 한개 삭제

### DIFF
--- a/module-api/src/main/java/com/example/onjeong/notification/service/NotificationService.java
+++ b/module-api/src/main/java/com/example/onjeong/notification/service/NotificationService.java
@@ -6,7 +6,6 @@ import com.example.onjeong.family.domain.Family;
 import com.example.onjeong.mail.domain.Mail;
 import com.example.onjeong.notification.domain.Notifications;
 import com.example.onjeong.notification.dto.NotificationDto;
-import com.example.onjeong.notification.dto.NotificationRegisterDto;
 import com.example.onjeong.notification.repository.NotificationRepository;
 import com.example.onjeong.profile.domain.Profile;
 import com.example.onjeong.question.domain.Answer;

--- a/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
+++ b/module-api/src/main/java/com/example/onjeong/user/service/UserService.java
@@ -78,7 +78,6 @@ public class UserService {
                 .userStatus(userJoinDto.getUserStatus())
                 .userBirth(userJoinDto.getUserBirth())
                 .userEmail(userJoinDto.getUserEmail())
-                .deviceToken(userJoinDto.getDeviceToken())
                 .role(UserRole.ROLE_USER)
                 .family(savedFamily)
                 .build();
@@ -116,7 +115,6 @@ public class UserService {
                 .userStatus(userJoinedDto.getUserStatus())
                 .userBirth(userJoinedDto.getUserBirth())
                 .userEmail(userJoinedDto.getUserEmail())
-                .deviceToken(userJoinedDto.getDeviceToken())
                 .role(UserRole.ROLE_USER)
                 .family(joinedUser.getFamily())
                 .build();

--- a/module-common/src/main/java/com/example/onjeong/user/dto/UserJoinDto.java
+++ b/module-common/src/main/java/com/example/onjeong/user/dto/UserJoinDto.java
@@ -14,5 +14,4 @@ public class UserJoinDto {
     private String userStatus;
     private LocalDate userBirth;
     private String userEmail;
-    private String deviceToken;
 }

--- a/module-common/src/main/java/com/example/onjeong/user/dto/UserJoinedDto.java
+++ b/module-common/src/main/java/com/example/onjeong/user/dto/UserJoinedDto.java
@@ -15,5 +15,4 @@ public class UserJoinedDto {
     private LocalDate userBirth;
     private String joinedNickname;
     private String userEmail;
-    private String deviceToken;
 }


### PR DESCRIPTION
## 개요
지난 회의에서 언급된 수정사항에 대해 작업했습니다. 

## 작업사항
- 회원가입시 유저 디바이스 토큰값은 받지 않도록 수정했습니다.
- 컴파일 시 오류가 난 코드를 제거했습니다.

## 변경로직
- 가족회원이 없는 회원가입과 가족회원이 있는 회원가입의 dto에서 deviceToken변수를 제거했습니다.
- 불필요한 import문 코드를 제거했습니다. (오류가 발생한 부분은 notification dto 폴더안에 NotificationRegisterDto파일이 존재하지 않아 생긴 오류였습니다.)

### 변경전
- 회원가입 dto에 deviceToken변수가 존재했습니다.
- 불필요한 import문 코드가 존재했습니다.

### 변경후
- 회원가입 dto에 deviceToken변수가 존재하지 않습니다.
- 불필요한 import문 코드가 존재하지 않습니다.